### PR TITLE
Opamification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build
+synml.native

--- a/README.md
+++ b/README.md
@@ -9,21 +9,12 @@ Ocaml > 4.01.0
 Quick and Dirty Installation Instructions
 -----------------------------------------
 
-    opam install core
-    opam install menhir
-    make
+    opam pin add myth https://github.com/psosera/myth.git
 
 Example Execution
 -----------------
 
-    >$ make
-    ocamlbuild  synml.native
-    Finished, 1 target (0 cached) in 00:00:00.
-    + menhir --ocamlc 'ocamlfind ocamlc -thread -annot -g -package str -package core -I src' --infer src/parser.mly
-    Warning: 5 states have shift/reduce conflicts.
-    Warning: 19 shift/reduce conflicts were arbitrarily resolved.
-    Finished, 58 targets (0 cached) in 00:00:15.
-    >$ ./synml.native tests/pldi-2015-benchmarks/list_stutter.ml
+    >$ myth tests/pldi-2015-benchmarks/list_stutter.ml
     let stutter : list -> list =
       let rec f1 (l1:list) : list =
         match l1 with

--- a/myth.install
+++ b/myth.install
@@ -1,0 +1,1 @@
+bin: ["_build/src/synml.native" {"myth"}]

--- a/opam
+++ b/opam
@@ -1,0 +1,17 @@
+opam-version: "1.3"
+name: "myth"
+version: "0.1.0"
+maintainer: "Peter-Michael Osera"
+authors: "Peter-Michael Osera"
+homepage: "https://github.com/psosera/myth"
+bug-reports: "https://github.com/psosera/myth/issues"
+dev-repo: "https://github.com/psosera/myth.git"
+build: [
+  [make]
+]
+depends: [
+  "ocamlfind" {build}
+  "menhir" {build}
+  "core"
+]
+available: [ ocaml-version > "4.01" ]


### PR DESCRIPTION
Small modifications to be opam-friendlier.

Note that your package is not currently friendly to architecture who do
not support native code. You should test that and build the .byte
version (and install it) in this case.

Also, your buildsystem contains some useless stuff, but I didn't want to
disturb that. :)